### PR TITLE
fix: export modal, input and button props

### DIFF
--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -62,4 +62,8 @@ interface DatepickerProps
   button?: Omit<ButtonProps, 'onClick' | 'children'>;
 }
 
-export type { WheelPickerProps, InputProps, ButtonProps, DatepickerProps, ModalProps };
+type DatepickerInputProps = Pick<DatepickerProps, 'input'>;
+type DatepickerModalProps = Pick<DatepickerProps, 'modal'>;
+type DatepickerButtonProps = Pick<DatepickerProps, 'button'>;
+
+export type { WheelPickerProps, InputProps, ButtonProps, DatepickerProps, ModalProps, DatepickerButtonProps, DatepickerInputProps, DatepickerModalProps };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
 import WheelDatePicker from './components/datepicker/datepicker';
 
+// components
 export { WheelDatePicker }
+
+// types
+export type {DatepickerProps, DatepickerInputProps, DatepickerButtonProps, DatepickerModalProps } from './components/types';


### PR DESCRIPTION
✅ What’s Changed
✅ Exported additional subtypes from DatepickerProps:

DatepickerInputProps

DatepickerModalProps

DatepickerButtonProps